### PR TITLE
Bugfixes - Snecko Cultist hitbox size, Totems attacking on turn they …

### DIFF
--- a/src/main/java/theAct/monsters/BabySnecko.java
+++ b/src/main/java/theAct/monsters/BabySnecko.java
@@ -44,8 +44,8 @@ public class BabySnecko extends AbstractMonster {
     private static final byte GLARE = 2;
     private static final String BITE_NAME = MOVES[0];
     private static final String GLARE_NAME = MOVES[1];
-    private static final int CONFUSE_AMOUNT = 3;
-    private static final int ASC_CONFUSE_AMOUNT = 4;
+    private static final int CONFUSE_AMOUNT = 1;
+    private static final int ASC_CONFUSE_AMOUNT = 2;
     private static final int BITE_DAMAGE = 9;
     private static final int ASC_BITE_DAMAGE = 11;
     private int biteDamage;

--- a/src/main/java/theAct/monsters/MamaSnecko.java
+++ b/src/main/java/theAct/monsters/MamaSnecko.java
@@ -55,8 +55,8 @@ public class MamaSnecko extends AbstractMonster {
     private static final String FURY_NAME = MOVES[4];
     private static final int TAIL_DAMAGE = 8;
     private static final int ASC_TAIL_DAMAGE = 10;
-    private static final int CONFUSE_AMOUNT = 8;
-    private static final int ASC_CONFUSE_AMOUNT = 12;
+    private static final int CONFUSE_AMOUNT = 4;
+    private static final int ASC_CONFUSE_AMOUNT = 5;
     private static final int TAIL_VULN = 2;
     private static final int ASC_TAIL_WEAK = 2;
     private static final int BITE_DAMAGE = 15;

--- a/src/main/java/theAct/monsters/SneckoCultist.java
+++ b/src/main/java/theAct/monsters/SneckoCultist.java
@@ -35,7 +35,7 @@ public class SneckoCultist extends AbstractMonster {
     private int  HP_MAX = 56;
     private static final float HB_X = 0F;
     private static final float HB_Y = 0F;
-    private static final float HB_W = 320.0F;
+    private static final float HB_W = 160.0F;
     private static final float HB_H = 240.0F;
     private int WHIP_DAMAGE = 17;
     private int TACKLE_DAMAGE = 10;
@@ -100,7 +100,7 @@ public class SneckoCultist extends AbstractMonster {
             case MoveBytes.CONFUSE_START:
             {
                 AbstractDungeon.actionManager.addToBottom(new ChangeStateAction(this, "ATTACK"));
-                AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(player, this, new RandomizePower(player,3),3));
+                AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(player, this, new RandomizePower(player,2),2));
                 if (this.talky) {
                     int r = MathUtils.random(1);
                     if (r == 0) {

--- a/src/main/java/theAct/monsters/TotemBoss/AbstractTotemSpawn.java
+++ b/src/main/java/theAct/monsters/TotemBoss/AbstractTotemSpawn.java
@@ -13,6 +13,7 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction.AttackEffect;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.actions.common.RollMoveAction;
+import com.megacrit.cardcrawl.actions.utility.TextAboveCreatureAction;
 import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.core.AbstractCreature;
@@ -25,6 +26,7 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.vfx.combat.GoldenSlashEffect;
+import theAct.TheActMod;
 import theAct.powers.BlockFromStrengthPower;
 import theAct.powers.TotemRevengeAttackPower;
 
@@ -64,12 +66,16 @@ public class AbstractTotemSpawn extends AbstractMonster {
 
     public Intent intentType = Intent.BUFF;
     private boolean wasFalling = false;
+    private boolean spawnedAfterFirst3 = false;
 
 
-    public AbstractTotemSpawn(String name, String ID, TotemBoss boss, String imgPath) {
+    public AbstractTotemSpawn(String name, String ID, TotemBoss boss, String imgPath, Boolean spawnedAfterFirst3) {
         super(name, ID, 420, 0.0F, 0F, 160.0F, 220.0F, null, -50.0F, 15.0F);
 
         this.powers.add(new TotemRevengeAttackPower(this));
+        this.spawnedAfterFirst3 = spawnedAfterFirst3;
+
+        if (this.spawnedAfterFirst3) TheActMod.logger.info("post-3 totem spawned");
 
         //ReflectionHacks.setPrivate(this, AbstractCreature.class,"HB_Y_OFFSET_DIST",-200F);
 
@@ -127,6 +133,10 @@ public class AbstractTotemSpawn extends AbstractMonster {
             this.setHp(baseHP);
         }
 
+        if (spawnedAfterFirst3){
+            this.setMove((byte)0, Intent.STUN);
+        }
+
     }
 
     public void totemAttack(){
@@ -141,11 +151,13 @@ public class AbstractTotemSpawn extends AbstractMonster {
         }
 
         switch (this.nextMove) {
+            case 0:
+                //Should only fire if they were spawned in
+                AbstractDungeon.actionManager.addToBottom(new TextAboveCreatureAction(this, TextAboveCreatureAction.TextType.STUNNED));
+                break;
             case 1:
                 // AbstractDungeon.actionManager.addToBottom(new ChangeStateAction(this, "ATTACK"));
-                AbstractDungeon.actionManager.addToBottom(new WaitAction(0.4F));
-                AbstractDungeon.actionManager.addToBottom(new VFXAction(new GoldenSlashEffect(AbstractDungeon.player.hb.cX - 60.0F * Settings.scale, AbstractDungeon.player.hb.cY, false), vfxSpeed));
-                AbstractDungeon.actionManager.addToBottom(new DamageAction(AbstractDungeon.player, (DamageInfo) this.damage.get(0), AttackEffect.NONE));
+                totemAttack();
                 break;
         }
 
@@ -228,7 +240,17 @@ public class AbstractTotemSpawn extends AbstractMonster {
 
 
     protected void getMove(int num) {
-        this.setMove((byte) 1, intentType);
+        if (this.spawnedAfterFirst3){
+            this.setMove((byte) 0, Intent.STUN);
+            this.spawnedAfterFirst3 = false;
+
+        } else {
+            getUniqueTotemMove();
+        }
+    }
+
+    public void getUniqueTotemMove(){
+
     }
 
     public void die() {

--- a/src/main/java/theAct/monsters/TotemBoss/AttackAndShieldTotem.java
+++ b/src/main/java/theAct/monsters/TotemBoss/AttackAndShieldTotem.java
@@ -39,8 +39,8 @@ public class AttackAndShieldTotem extends AbstractTotemSpawn {
     public Integer attackDmg;
     public Integer secondaryEffect;
 
-    public AttackAndShieldTotem(TotemBoss boss) {
-        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemorange.png"));
+    public AttackAndShieldTotem(TotemBoss boss, boolean spawnedIn) {
+        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemorange.png"), spawnedIn);
         this.loadAnimation(TheActMod.assetPath("images/monsters/totemboss/purple/Totem.atlas"), TheActMod.assetPath("images/monsters/totemboss/purple/Totem.json"), 1.0F);
 
         AnimationState.TrackEntry e = this.state.setAnimation(0, "idle", true);
@@ -64,11 +64,6 @@ public class AttackAndShieldTotem extends AbstractTotemSpawn {
 
 
 
-    public void takeTurn() {
-        totemAttack();
-
-    }
-
     @Override
     public void totemAttack() {
         AbstractDungeon.actionManager.addToBottom(new WaitAction(0.4F)); AbstractDungeon.actionManager.addToBottom(new SFXAction("ATTACK_MAGIC_BEAM_SHORT", 0.5F));
@@ -85,9 +80,10 @@ public class AttackAndShieldTotem extends AbstractTotemSpawn {
         }
     }
 
-    protected void getMove(int num)
-    {
-        this.setMove((byte)1, Intent.ATTACK_DEFEND, this.attackDmg);
+    public void getUniqueTotemMove() {
+
+            this.setMove((byte) 1, Intent.ATTACK_DEFEND, this.attackDmg);
+
     }
 
     static {

--- a/src/main/java/theAct/monsters/TotemBoss/BashTotem.java
+++ b/src/main/java/theAct/monsters/TotemBoss/BashTotem.java
@@ -33,8 +33,8 @@ public class BashTotem extends AbstractTotemSpawn {
 
     public Integer attackDmg;
 
-    public BashTotem(TotemBoss boss) {
-        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemred.png"));
+    public BashTotem(TotemBoss boss, boolean spawnedIn) {
+        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemred.png"), spawnedIn);
         this.loadAnimation(TheActMod.assetPath("images/monsters/totemboss/red/Totem.atlas"), TheActMod.assetPath("images/monsters/totemboss/red/Totem.json"), 1.0F);
 
         AnimationState.TrackEntry e = this.state.setAnimation(0, "idle", true);
@@ -53,12 +53,6 @@ public class BashTotem extends AbstractTotemSpawn {
         this.damage.add(new DamageInfo(this, this.attackDmg));
     }
 
-
-
-    public void takeTurn() {
-        totemAttack();
-    }
-
     @Override
     public void totemAttack() {
         AbstractDungeon.actionManager.addToBottom(new WaitAction(0.4F));
@@ -68,9 +62,7 @@ public class BashTotem extends AbstractTotemSpawn {
         AbstractDungeon.actionManager.addToBottom(new DamageAction(AbstractDungeon.player, this.damage.get(0), AttackEffect.NONE));
     }
 
-    protected void getMove(int num)
-    {
-        this.setMove((byte)1, intentType, this.attackDmg);
+    public void getUniqueTotemMove() {this.setMove((byte)1, intentType, this.attackDmg);
     }
 
     static {

--- a/src/main/java/theAct/monsters/TotemBoss/BuffTotem.java
+++ b/src/main/java/theAct/monsters/TotemBoss/BuffTotem.java
@@ -41,8 +41,8 @@ public class BuffTotem extends AbstractTotemSpawn {
 
     public Integer secondaryEffect;
 
-    public BuffTotem(TotemBoss boss) {
-        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemgreen.png"));
+    public BuffTotem(TotemBoss boss, boolean spawnedIn) {
+        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemgreen.png"), spawnedIn);
         this.loadAnimation(TheActMod.assetPath("images/monsters/totemboss/green/Totem.atlas"), TheActMod.assetPath("images/monsters/totemboss/green/Totem.json"), 1.0F);
 
         AnimationState.TrackEntry e = this.state.setAnimation(0, "idle", true);
@@ -65,12 +65,6 @@ public class BuffTotem extends AbstractTotemSpawn {
     }
 
 
-
-    public void takeTurn() {
-        totemAttack();
-
-    }
-
     @Override
     public void totemAttack() {
         // AbstractDungeon.actionManager.addToBottom(new ChangeStateAction(this, "ATTACK"));
@@ -91,9 +85,7 @@ public class BuffTotem extends AbstractTotemSpawn {
 
     }
 
-    protected void getMove(int num)
-    {
-        this.setMove((byte)1, intentType, this.attackDmg);
+    public void getUniqueTotemMove() {this.setMove((byte)1, intentType, this.attackDmg);
     }
 
     static {

--- a/src/main/java/theAct/monsters/TotemBoss/ConfuseTotem.java
+++ b/src/main/java/theAct/monsters/TotemBoss/ConfuseTotem.java
@@ -33,33 +33,25 @@ public class ConfuseTotem extends AbstractTotemSpawn {
     public Integer secondaryEffect;
 
 
-    public ConfuseTotem(TotemBoss boss) {
-        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemyellow.png"));
+    public ConfuseTotem(TotemBoss boss, boolean spawnedIn) {
+        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemyellow.png"), spawnedIn);
         this.loadAnimation(TheActMod.assetPath("images/monsters/totemboss/white/Totem.atlas"), TheActMod.assetPath("images/monsters/totemboss/white/Totem.json"), 1.0F);
 
         AnimationState.TrackEntry e = this.state.setAnimation(0, "idle", true);
         e.setTime(e.getEndTime() * MathUtils.random());
 
         if (AbstractDungeon.ascensionLevel >= 19) {
-            this.secondaryEffect = 5;
+            this.secondaryEffect = 4;
         } else if (AbstractDungeon.ascensionLevel >= 4) {
-            this.secondaryEffect = 4;
+            this.secondaryEffect = 3;
         } else {
-            this.secondaryEffect = 4;
+            this.secondaryEffect = 3;
         }
 
         this.intentType = Intent.DEBUFF;
 
     }
 
-
-
-    public void takeTurn() {
-
-        totemAttack();
-
-
-    }
 
     @Override
     public void totemAttack() {
@@ -72,9 +64,7 @@ public class ConfuseTotem extends AbstractTotemSpawn {
 
     }
 
-    protected void getMove(int num)
-    {
-        this.setMove((byte)1, intentType);
+    public void getUniqueTotemMove() {this.setMove((byte)1, intentType);
     }
     static {
         monsterStrings = CardCrawlGame.languagePack.getMonsterStrings(ID);

--- a/src/main/java/theAct/monsters/TotemBoss/DebuffTotem.java
+++ b/src/main/java/theAct/monsters/TotemBoss/DebuffTotem.java
@@ -44,8 +44,8 @@ public class DebuffTotem extends AbstractTotemSpawn {
     public Integer secondaryEffect;
 
 
-    public DebuffTotem(TotemBoss boss) {
-        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemyellow.png"));
+    public DebuffTotem(TotemBoss boss, boolean spawnedIn) {
+        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemyellow.png"), spawnedIn);
         this.loadAnimation(TheActMod.assetPath("images/monsters/totemboss/orange/Totem.atlas"), TheActMod.assetPath("images/monsters/totemboss/orange/Totem.json"), 1.0F);
 
         AnimationState.TrackEntry e = this.state.setAnimation(0, "idle", true);
@@ -53,7 +53,7 @@ public class DebuffTotem extends AbstractTotemSpawn {
 
         if (AbstractDungeon.ascensionLevel >= 19) {
             this.attackDmg = 5;
-            this.secondaryEffect = 3;
+            this.secondaryEffect = 2;
         } else if (AbstractDungeon.ascensionLevel >= 4) {
             this.attackDmg = 5;
             this.secondaryEffect = 2;
@@ -69,13 +69,6 @@ public class DebuffTotem extends AbstractTotemSpawn {
 
 
 
-    public void takeTurn() {
-
-        totemAttack();
-
-
-    }
-
     @Override
     public void totemAttack() {
         // AbstractDungeon.actionManager.addToBottom(new ChangeStateAction(this, "ATTACK"));
@@ -90,9 +83,7 @@ public class DebuffTotem extends AbstractTotemSpawn {
 
     }
 
-    protected void getMove(int num)
-    {
-        this.setMove((byte)1, intentType, this.attackDmg);
+    public void getUniqueTotemMove() {this.setMove((byte)1, intentType, this.attackDmg);
     }
     static {
         monsterStrings = CardCrawlGame.languagePack.getMonsterStrings(ID);

--- a/src/main/java/theAct/monsters/TotemBoss/DoubleStrikeTotem.java
+++ b/src/main/java/theAct/monsters/TotemBoss/DoubleStrikeTotem.java
@@ -34,8 +34,8 @@ public class DoubleStrikeTotem extends AbstractTotemSpawn {
 
     public Integer secondaryEffect;
 
-    public DoubleStrikeTotem(TotemBoss boss) {
-        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemorange.png"));
+    public DoubleStrikeTotem(TotemBoss boss, boolean spawnedIn) {
+        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemorange.png"), spawnedIn);
         this.loadAnimation(TheActMod.assetPath("images/monsters/totemboss/yellow/Totem.atlas"), TheActMod.assetPath("images/monsters/totemboss/yellow/Totem.json"), 1.0F);
 
         AnimationState.TrackEntry e = this.state.setAnimation(0, "idle", true);
@@ -57,11 +57,6 @@ public class DoubleStrikeTotem extends AbstractTotemSpawn {
         this.damage.add(new DamageInfo(this, this.attackDmg));
     }
 
-
-
-    public void takeTurn() {
-        totemAttack();
-    }
 
     @Override
     public void totemAttack() {
@@ -85,9 +80,7 @@ public class DoubleStrikeTotem extends AbstractTotemSpawn {
 
     }
 
-    protected void getMove(int num)
-    {
-        this.setMove((byte)1, Intent.ATTACK, this.attackDmg, 2, true);
+    public void getUniqueTotemMove() {this.setMove((byte)1, Intent.ATTACK, this.attackDmg, 2, true);
     }
 
 

--- a/src/main/java/theAct/monsters/TotemBoss/ShieldOtherTotem.java
+++ b/src/main/java/theAct/monsters/TotemBoss/ShieldOtherTotem.java
@@ -31,8 +31,8 @@ public class ShieldOtherTotem extends AbstractTotemSpawn {
     public Integer secondaryEffect;
 
 
-    public ShieldOtherTotem(TotemBoss boss) {
-        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemcyan.png"));
+    public ShieldOtherTotem(TotemBoss boss, boolean spawnedIn) {
+        super(NAME, ID, boss, TheActMod.assetPath("images/monsters/totemboss/totemcyan.png"), spawnedIn);
         this.loadAnimation(TheActMod.assetPath("images/monsters/totemboss/cyan/Totem.atlas"), TheActMod.assetPath("images/monsters/totemboss/cyan/Totem.json"), 1.0F);
 
         AnimationState.TrackEntry e = this.state.setAnimation(0, "idle", true);
@@ -53,11 +53,6 @@ public class ShieldOtherTotem extends AbstractTotemSpawn {
     }
 
 
-
-    public void takeTurn() {
-        totemAttack();
-    }
-
     @Override
     public void totemAttack() {
         // AbstractDungeon.actionManager.addToBottom(new ChangeStateAction(this, "ATTACK"));
@@ -76,9 +71,7 @@ public class ShieldOtherTotem extends AbstractTotemSpawn {
         }
     }
 
-    protected void getMove(int num)
-    {
-        this.setMove((byte)1, intentType);
+    public void getUniqueTotemMove() {this.setMove((byte)1, intentType);
     }
     static {
         monsterStrings = CardCrawlGame.languagePack.getMonsterStrings(ID);

--- a/src/main/java/theAct/monsters/TotemBoss/TotemBoss.java
+++ b/src/main/java/theAct/monsters/TotemBoss/TotemBoss.java
@@ -53,6 +53,7 @@ public class TotemBoss extends AbstractMonster {
     public boolean stopTotemFall;
     private float totemSfxTimer = 0.f;
     public int encounterSlotsUsed = 1;
+    public int totemsSpawned = 0;
     public ArrayList<Integer> remainingTotems = new ArrayList<>();
     public ArrayList<AbstractTotemSpawn> livingTotems = new ArrayList<>();
 
@@ -135,33 +136,35 @@ public class TotemBoss extends AbstractMonster {
             AbstractTotemSpawn m = null;
             Integer chosen = remainingTotems.get(AbstractDungeon.cardRng.random(0, remainingTotems.size() - 1));
             TheActMod.logger.info("Choosing Totem");
+            Boolean post3 = false;
+            if (this.totemsSpawned >= 3) post3 = true;
             switch (chosen) {
                 case 1:
                     TheActMod.logger.info("Bash Totem Picked");
-                    m = new BashTotem(this);
+                    m = new BashTotem(this, post3);
                     break;
                 case 2:
                     TheActMod.logger.info("Double Strike Totem Picked");
-                    m = new DoubleStrikeTotem(this);
+                    m = new DoubleStrikeTotem(this, post3);
                     break;
                 case 3:
-                    m = new AttackAndShieldTotem(this);
+                    m = new AttackAndShieldTotem(this, post3);
                     TheActMod.logger.info("Attack/Block Totem Picked");
                     break;
                 case 4:
-                    m = new ShieldOtherTotem(this);
+                    m = new ShieldOtherTotem(this, post3);
                     TheActMod.logger.info("Shield Totem Picked");
                     break;
                 case 5:
-                    m = new BuffTotem(this);
+                    m = new BuffTotem(this, post3);
                     TheActMod.logger.info("Buff Totem Picked");
                     break;
                 case 6:
-                    m = new DebuffTotem(this);
+                    m = new DebuffTotem(this, post3);
                     TheActMod.logger.info("Debuff Totem Picked");
                     break;
                 case 7:
-                    m = new ConfuseTotem(this);
+                    m = new ConfuseTotem(this, post3);
                     TheActMod.logger.info("Confuse Totem Picked - This should only happen with Bosses are Tougher ascension.");
                     break;
             }
@@ -173,6 +176,7 @@ public class TotemBoss extends AbstractMonster {
             TheActMod.logger.info("Spawning Monster");
 
             AbstractDungeon.actionManager.addToBottom(new SpawnMonsterAction(m,false,-99));
+            this.totemsSpawned++;
 
         }
     }

--- a/src/main/java/theAct/powers/RandomizePower.java
+++ b/src/main/java/theAct/powers/RandomizePower.java
@@ -16,6 +16,7 @@ public class RandomizePower extends Power implements OnCardDrawPower {
     public static final String powerID = TheActMod.makeID("RandomizePower");
     private static final PowerStrings strings = CardCrawlGame.languagePack.getPowerStrings(powerID);
     private String[] DESCRIPTIONS = strings.DESCRIPTIONS;
+    private int cardsRandomizedThisTurn;
 
     public RandomizePower(AbstractCreature p, int stackAmount) {
         this.owner = p;
@@ -26,6 +27,7 @@ public class RandomizePower extends Power implements OnCardDrawPower {
         this.amount = stackAmount;
         this.updateDescription();
         this.isTurnBased = true;
+        this.cardsRandomizedThisTurn = 0;
     }
 
     @Override
@@ -40,15 +42,28 @@ public class RandomizePower extends Power implements OnCardDrawPower {
 
     @Override
     public void onCardDraw(AbstractCard c){
-        if (amount > 0 && c.cost >= 0) {
+        if (amount > 0 && c.cost >= 0 && this.cardsRandomizedThisTurn < 2) {
             int newCost = AbstractDungeon.cardRandomRng.random(3);
             c.superFlash(Color.LIME.cpy());
             if (c.cost != newCost) {
                 c.costForTurn = newCost;
                 c.isCostModifiedForTurn = true;
             }
-            reducePower(1);
+            this.cardsRandomizedThisTurn++;
         }
+    }
+
+    @Override
+    public void atEndOfTurn(boolean isPlayer) {
+        super.atEndOfTurn(isPlayer);
+        cardsRandomizedThisTurn = 0;
+    }
+
+    @Override
+    public void atStartOfTurnPostDraw() {
+        super.atStartOfTurnPostDraw();
+        reducePower(1);
+        this.flash();
     }
 
     @Override

--- a/src/main/resources/theActAssets/localization/eng/powers.json
+++ b/src/main/resources/theActAssets/localization/eng/powers.json
@@ -95,9 +95,9 @@
 	"theJungle:RandomizePower": {
 		"NAME": "Selective Confusion",
 		"DESCRIPTIONS": [
-			"Randomize the cost of the next card you draw.",
-			"Randomizes the cost of the next ",
-			" cards you draw."
+			"Randomize the cost of the first 2 cards you draw next turn.",
+			"Randomize the cost of the first 2 cards you draw for the next ",
+			" turns."
 		]
 	},
 	"theJungle:CautiousPower": {


### PR DESCRIPTION
PATCHNOTES

Reworked Selective Confusion - now randomizes the cost of the first 2 cards you draw each turn.  The debuff reduces itself by 1 each turn.  This allows the debuff to remain visible and the effect read instead of it being applied during the enemy turn, and completely consumed upon the first few cards of the player turn being drawn.

Fixed an issue with Snecko Cultists having a very wide health bar and hitbox.

Fixed an issue with Totems beyond the first 3 in the Totem Speaker fight attacking the turn they spawn in.  They should not attack until the following turn.